### PR TITLE
conformity on isotp_user.h

### DIFF
--- a/isotp_user.h
+++ b/isotp_user.h
@@ -1,6 +1,12 @@
 #ifndef __ISOTP_USER_H__
 #define __ISOTP_USER_H__
 
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* user implemented, print debug message */
 void isotp_user_debug(const char* message, ...);
 
@@ -11,6 +17,10 @@ int  isotp_user_send_can(const uint32_t arbitration_id,
 
 /* user implemented, get millisecond */
 uint32_t isotp_user_get_ms(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // __ISOTP_H__
 


### PR DESCRIPTION
To be able to compile with C++ compilers, it's common practice to offer extern "C" on a makro basis. All C-based system includes of Linux do so. I suggest to do it likewise here.

Another thing is to `#include <stdint.h>`. The problem is that some compilers often automatically export names defined in various headers or provided types before such standards were in place.
Details can be found here: https://stackoverflow.com/questions/11069108/uint32-t-does-not-name-a-type